### PR TITLE
[Security] Bump dependency.keycloak.version from 4.5.0.Final to 5.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dependency.mysql.version>5.1.47</dependency.mysql.version>
         <dependency.mariadb.version>2.2.5</dependency.mariadb.version>
         <dependency.antlr.version>3.5.2</dependency.antlr.version>
-        <dependency.keycloak.version>4.5.0.Final</dependency.keycloak.version>
+        <dependency.keycloak.version>5.0.0</dependency.keycloak.version>
         <dependency.jboss.logging.version>3.3.2.Final</dependency.jboss.logging.version>
         <dependency.camel.version>2.23.1</dependency.camel.version>
         <dependency.activemq.version>5.15.8</dependency.activemq.version>


### PR DESCRIPTION
Bumps `dependency.keycloak.version` from 4.5.0.Final to 5.0.0.

Updates `keycloak-authz-client` from 4.5.0.Final to 5.0.0

Updates `keycloak-core` from 4.5.0.Final to 5.0.0
- [Release notes](https://github.com/keycloak/keycloak/releases)
- [Changelog](https://github.com/keycloak/keycloak/blob/5.0.0/release-details)
- [Commits](https://github.com/keycloak/keycloak/compare/4.5.0.Final...5.0.0)

Updates `keycloak-common` from 4.5.0.Final to 5.0.0
- [Release notes](https://github.com/keycloak/keycloak/releases)
- [Changelog](https://github.com/keycloak/keycloak/blob/5.0.0/release-details)
- [Commits](https://github.com/keycloak/keycloak/compare/4.5.0.Final...5.0.0)

Updates `keycloak-adapter-core` from 4.5.0.Final to 5.0.0
- [Release notes](https://github.com/keycloak/keycloak/releases)
- [Changelog](https://github.com/keycloak/keycloak/blob/5.0.0/release-details)
- [Commits](https://github.com/keycloak/keycloak/compare/4.5.0.Final...5.0.0)

Updates `keycloak-adapter-spi` from 4.5.0.Final to 5.0.0

Updates `keycloak-servlet-adapter-spi` from 4.5.0.Final to 5.0.0

Signed-off-by: dependabot[bot] <support@dependabot.com>